### PR TITLE
[hotfix-22] Fix the error when running preprocess.py

### DIFF
--- a/utils/audio.py
+++ b/utils/audio.py
@@ -37,8 +37,8 @@ _inv_mel_basis = None
 
 def _build_mel_basis(hparams):
     assert hparams.fmax <= hparams.sample_rate // 2
-    return librosa.filters.mel(hparams.sample_rate,
-                               hparams.n_fft,
+    return librosa.filters.mel(sr=hparams.sample_rate,
+                               n_fft=hparams.n_fft,
                                n_mels=hparams.acoustic_dim,
                                fmin=hparams.fmin,
                                fmax=hparams.fmax)


### PR DESCRIPTION
Fix the error when running preprocess.py to extract pitch and melody:
TypeError: mel() takes 0 positional arguments but 2 positional arguments (and 3 keyword-only arguments) were given